### PR TITLE
scan classpath, when url is empty.

### DIFF
--- a/src/main/java/com/edugility/jpa/maven/plugin/ListEntityClassnamesMojo.java
+++ b/src/main/java/com/edugility/jpa/maven/plugin/ListEntityClassnamesMojo.java
@@ -520,7 +520,7 @@ public class ListEntityClassnamesMojo extends AbstractJPAMojo {
    */
   private final Set<URL> initializeURLs() throws DependencyResolutionRequiredException {
     Set<URL> urls = this.getURLs();
-    if (urls == null) {
+    if (urls == null || urls.isEmpty()) {
       urls = this.getTestClasspathURLs();
     }
     assert urls != null;


### PR DESCRIPTION
I found it's empty, when not explicitly specified.
( I'm using maven 3.0.5 )
