### PR TITLE
Solve issue when using only defaultPropertyName in configuration.

### DIFF
--- a/src/main/java/com/edugility/jpa/maven/plugin/ListEntityClassnamesMojo.java
+++ b/src/main/java/com/edugility/jpa/maven/plugin/ListEntityClassnamesMojo.java
@@ -1299,7 +1299,7 @@ public class ListEntityClassnamesMojo extends AbstractJPAMojo {
       }
     }
     if (propertyName == null) {
-      propertyName = DEFAULT_DEFAULT_PROPERTY_NAME;
+      propertyName = this.getDefaultPropertyName();
     }
     return propertyName;
   }


### PR DESCRIPTION
We have found a bug when using onlye defaultPropertyName in configuration, the new propertyName is not used, falling back to DEFAULT_PROPERTY_NAME, with this fix, this situation is solved.